### PR TITLE
ADM-212: Calculate percentage of different block reasons in the latest iteration

### DIFF
--- a/backend/src/models/kanban/JiraBlockReasonEnum.ts
+++ b/backend/src/models/kanban/JiraBlockReasonEnum.ts
@@ -1,0 +1,10 @@
+export enum JiraBlockReasonEnum {
+  DEPENDENCIES_NOT_WORK = "dependencies_not_work",
+  SIT_ENV_DOWN = "sit_env_down",
+  PRIORITY_CHANGE = "priority_change",
+  SOLUTION_REVIEW = "solution_review",
+  PR_REVIEW = "pr_review",
+  QUESTION_TO_BE_ANSWERED = "question_to_be_answered",
+  TAKE_LEAVE = "take_leave",
+  OTHERS = "others",
+}

--- a/backend/src/services/GenerateReporter/GenerateSprintReporterService.ts
+++ b/backend/src/services/GenerateReporter/GenerateSprintReporterService.ts
@@ -5,6 +5,7 @@ import {
 } from "../../contract/GenerateReporter/GenerateReporterRequestBody";
 import { StoryPointsAndCycleTimeRequest } from "../../contract/kanban/KanbanStoryPointParameterVerify";
 import { JiraCardResponse } from "../../contract/kanban/KanbanStoryPointResponse";
+import { JiraBlockReasonEnum } from "../../models/kanban/JiraBlockReasonEnum";
 import { Cards } from "../../models/kanban/RequestKanbanResults";
 import { Sprint } from "../../models/kanban/Sprint";
 import { CalculateCardCycleTime } from "../kanban/CalculateCycleTime";
@@ -19,6 +20,7 @@ const KanbanKeyIdentifierMap: { [key: string]: "projectKey" | "teamName" } = {
 
 export class GenerateSprintReporterService {
   private cards?: Cards;
+  private sprints?: Sprint[];
   private blockPercentage?: Map<string, any>;
   async fetchIterationInfoFromKanban(
     request: GenerateReportRequest
@@ -29,36 +31,117 @@ export class GenerateSprintReporterService {
       kanbanSetting.token,
       kanbanSetting.site
     );
-    let model: StoryPointsAndCycleTimeRequest =
-      new StoryPointsAndCycleTimeRequest(
-        kanbanSetting.token,
-        kanbanSetting.type,
-        kanbanSetting.site,
-        kanbanSetting[KanbanKeyIdentifierMap[kanbanSetting.type]],
-        kanbanSetting.boardId,
-        kanbanSetting.doneColumn,
-        request.startTime,
-        request.endTime,
-        kanbanSetting.targetFields,
-        kanbanSetting.treatFlagCardAsBlock
-      );
+    let model: StoryPointsAndCycleTimeRequest = new StoryPointsAndCycleTimeRequest(
+      kanbanSetting.token,
+      kanbanSetting.type,
+      kanbanSetting.site,
+      kanbanSetting[KanbanKeyIdentifierMap[kanbanSetting.type]],
+      kanbanSetting.boardId,
+      kanbanSetting.doneColumn,
+      request.startTime,
+      request.endTime,
+      kanbanSetting.targetFields,
+      kanbanSetting.treatFlagCardAsBlock
+    );
     this.cards = await kanban.getStoryPointsAndCycleTime(
       model,
       kanbanSetting.boardColumns,
       kanbanSetting.users
     );
     if (kanban instanceof Jira) {
-      let sprintPercentageMap: Map<string, any> =
-        this.calculateIterationBlockedAndDevelopingPercentage(
-          this.mapCardsByIteration(this.cards.matchedCards),
-          kanbanSetting.boardColumns
-        );
+      let sprintPercentageMap: Map<
+        string,
+        any
+      > = this.calculateIterationBlockedAndDevelopingPercentage(
+        this.mapCardsByIteration(this.cards.matchedCards),
+        kanbanSetting.boardColumns
+      );
       let sprints: Sprint[] = await kanban.getAllSprintsByBoardId(model);
       this.blockPercentage = this.sortBySprintStartDate(
         sprintPercentageMap,
         sprints
       );
     }
+  }
+  getLatestIterationSprintName(sprints: Sprint[]): string {
+    const sortedSprints = sprints
+      .filter((sprint) => sprint.startDate)
+      .sort((a, b) => Date.parse(a.startDate) - Date.parse(b.startDate));
+    return sortedSprints.length > 0
+      ? sortedSprints[sortedSprints.length - 1].name
+      : "";
+  }
+
+  getAllCardsByLatestSprintName(
+    cards: JiraCardResponse[],
+    sprintName: string
+  ): JiraCardResponse[] {
+    const allCardsInLatestSprint: JiraCardResponse[] = [];
+    cards.forEach((card) => {
+      if (card.baseInfo.fields.sprint === sprintName) {
+        allCardsInLatestSprint[allCardsInLatestSprint.length] = card;
+      }
+    });
+    return allCardsInLatestSprint;
+  }
+
+  calculateBlockReasonPercentage(
+    cards: JiraCardResponse[],
+    boardColumns: RequestKanbanColumnSetting[] = [],
+    sprints: Sprint[]
+  ): Map<string, number> {
+    let totalBlockTime = 0;
+
+    const initBlockTimeForEveryReasonMap: Map<
+      string,
+      number
+    > = this.initTotalBlockTimeForEveryReasonMap();
+    const sprintName = this.getLatestIterationSprintName(sprints);
+    const matchedCards = this.getAllCardsByLatestSprintName(cards, sprintName);
+    if (matchedCards.length === 0) {
+      return initBlockTimeForEveryReasonMap;
+    }
+
+    for (const card of matchedCards) {
+      const blockReason = card.baseInfo.fields.label || "";
+      const cardCycleTime = CalculateCardCycleTime(card, boardColumns);
+      totalBlockTime += cardCycleTime.steps.blocked;
+
+      if (!initBlockTimeForEveryReasonMap.has(blockReason)) {
+        initBlockTimeForEveryReasonMap.set(
+          JiraBlockReasonEnum.OTHERS,
+          initBlockTimeForEveryReasonMap.get(JiraBlockReasonEnum.OTHERS) ||
+            0 + cardCycleTime.steps.blocked
+        );
+      } else {
+        initBlockTimeForEveryReasonMap.set(
+          blockReason,
+          initBlockTimeForEveryReasonMap.get(blockReason) ||
+            0 + cardCycleTime.steps.blocked
+        );
+      }
+    }
+
+    const blockTimePercentageForEveryReasonMap: Map<string, number> = new Map<
+      string,
+      number
+    >();
+
+    initBlockTimeForEveryReasonMap.forEach((value, key) => {
+      const blockedReasonPercentage = parseFloat(
+        (Math.floor((value / totalBlockTime) * 100) / 100).toFixed(2)
+      );
+      blockTimePercentageForEveryReasonMap.set(key, blockedReasonPercentage);
+    });
+    return blockTimePercentageForEveryReasonMap;
+  }
+
+  initTotalBlockTimeForEveryReasonMap(): Map<string, number> {
+    const totalBlockTimeForEveryReasonMap = new Map<string, number>();
+    for (let reason in JiraBlockReasonEnum) {
+      totalBlockTimeForEveryReasonMap.set(reason, 0);
+    }
+    return totalBlockTimeForEveryReasonMap;
   }
   mapCardsByIteration(
     cards: JiraCardResponse[]

--- a/backend/tests/services/GenerateKanbanReporter/GenerateSprintReporterService.test.ts
+++ b/backend/tests/services/GenerateKanbanReporter/GenerateSprintReporterService.test.ts
@@ -224,3 +224,177 @@ describe("generate Kanban reporter service", () => {
     sinon.restore();
   });
 });
+
+describe("calculate percentage of different block reasons in the latest iteration", () => {
+  const service = new GenerateSprintReporterService();
+  const sprint1JiraCardField: JiraCardField = new JiraCardField();
+  const sprint2JiraCardField: JiraCardField = new JiraCardField();
+  const sprint1 = new Sprint(
+    1,
+    "closed",
+    "test Sprint 1",
+    "2020-05-26T03:20:43.632Z",
+    "2020-06-09T03:20:37.000Z",
+    "2020-07-22T01:46:20.917Z"
+  );
+  const sprint2 = new Sprint(
+    4,
+    "closed",
+    "test Sprint 2",
+    "2020-07-22T01:48:39.455Z",
+    "2020-08-05T01:48:37.000Z",
+    "2020-07-22T01:49:26.508Z"
+  );
+  const sprint3 = new Sprint(9, "future", "test Sprint 5");
+  let sprints: Sprint[] = [sprint1, sprint2, sprint3];
+
+  sprint1JiraCardField.sprint = "test sprint 1";
+  sprint2JiraCardField.sprint = "test Sprint 2";
+  sprint2JiraCardField.label = "dependencies_not_work";
+
+  const sprint1JiraCard: JiraCard = { fields: sprint1JiraCardField, key: "" };
+  const sprint2JiraCard: JiraCard = { fields: sprint2JiraCardField, key: "" };
+
+  const cycleTimeArray1: CycleTimeInfo[] = [
+    { column: "DOING", day: 1 },
+    { column: "WAIT", day: 2 },
+    { column: "TEST", day: 3 },
+    { column: "BLOCKED", day: 4 },
+    { column: "REVIEW", day: 5 },
+  ];
+  const cycleTimeArray2: CycleTimeInfo[] = [
+    { column: "DOING", day: 2 },
+    { column: "WAIT", day: 3 },
+    { column: "TEST", day: 4 },
+    { column: "BLOCKED", day: 5 },
+    { column: "REVIEW", day: 6 },
+  ];
+
+  const cards = [
+    new JiraCardResponse(sprint1JiraCard, cycleTimeArray1),
+    new JiraCardResponse(sprint2JiraCard, cycleTimeArray2),
+  ];
+
+  const boardColumns: RequestKanbanColumnSetting[] = [
+    { name: "DOING", value: "In Dev" },
+    { name: "WAIT", value: "Waiting for testing" },
+    { name: "TEST", value: "Testing" },
+    { name: "BLOCKED", value: "Block" },
+    { name: "REVIEW", value: "Review" },
+  ];
+
+  it("should return the latest sprint name", async () => {
+    const latestSprintName = service.getLatestIterationSprintName(sprints);
+
+    expect(latestSprintName).equal("test Sprint 2");
+  });
+
+  it("should return an empty string when there are no matched cards", async () => {
+    const sprintWithoutMatchedCards = [sprint3];
+
+    const latestSprintName = service.getLatestIterationSprintName(
+      sprintWithoutMatchedCards
+    );
+
+    expect(latestSprintName).equal("");
+  });
+
+  it("should return the latest iteration cards by sprint name", async () => {
+    const cards = [
+      new JiraCardResponse(sprint1JiraCard, []),
+      new JiraCardResponse(sprint2JiraCard, []),
+    ];
+
+    const latestCards = service.getAllCardsByLatestSprintName(
+      cards,
+      "test Sprint 2"
+    );
+
+    console.log(latestCards[0].baseInfo.fields);
+
+    expect(latestCards[0].baseInfo.fields.sprint).deep.equal("test Sprint 2");
+    expect(latestCards[0]).deep.equal(cards[1]);
+    expect(latestCards.length).deep.equal(1);
+  });
+
+  it("should return blocked reason percentage", async () => {
+    sinon
+      .stub(
+        GenerateSprintReporterService.prototype,
+        "initTotalBlockTimeForEveryReasonMap"
+      )
+      .returns(
+        new Map([
+          ["dependencies_not_work", 0],
+          ["unknown", 0],
+        ])
+      );
+
+    sinon
+      .stub(
+        GenerateSprintReporterService.prototype,
+        "getLatestIterationSprintName"
+      )
+      .returns("test Sprint 2");
+
+    const matchedCards = new JiraCardResponse(sprint2JiraCard, cycleTimeArray2);
+    const list: JiraCardResponse[] = [matchedCards];
+    sinon
+      .stub(
+        GenerateSprintReporterService.prototype,
+        "getAllCardsByLatestSprintName"
+      )
+      .returns(list);
+
+    const blockedPercentageByReason = service.calculateBlockReasonPercentage(
+      cards,
+      boardColumns,
+      sprints
+    );
+
+    expect(blockedPercentageByReason.get("dependencies_not_work")).equal(1);
+    expect(blockedPercentageByReason.get("unknown")).equal(0);
+
+    sinon.restore();
+  });
+
+  it("should return a initMap when there are no matched card", async () => {
+    sinon
+      .stub(
+        GenerateSprintReporterService.prototype,
+        "getLatestIterationSprintName"
+      )
+      .returns("test Sprint 2");
+    sinon
+      .stub(
+        GenerateSprintReporterService.prototype,
+        "getAllCardsByLatestSprintName"
+      )
+      .returns([]);
+    sinon
+      .stub(
+        GenerateSprintReporterService.prototype,
+        "initTotalBlockTimeForEveryReasonMap"
+      )
+      .returns(
+        new Map([
+          ["dependencies_not_work", 0],
+          ["unknown", 0],
+        ])
+      );
+    const map = service.calculateBlockReasonPercentage(
+      cards,
+      boardColumns,
+      sprints
+    );
+
+    expect(map).deep.equal(
+      new Map([
+        ["dependencies_not_work", 0],
+        ["unknown", 0],
+      ])
+    );
+
+    sinon.restore();
+  });
+});


### PR DESCRIPTION
# what
[ADM-212](https://dorametrics.atlassian.net/jira/software/projects/ADM/boards/2?selectedIssue=ADM-212)

# why
We want to calculate percentage of different block reasons in the latest iteration

# how
function getLatestIterationSprintName
function getAllCardsByLatestSprintName
function calculateBlockReasonPercentag
function initTotalBlockTimeForEveryReasonMap